### PR TITLE
Replace badge with chip in UI copy

### DIFF
--- a/app/views/admin/badge_achievements/award.html.erb
+++ b/app/views/admin/badge_achievements/award.html.erb
@@ -1,11 +1,11 @@
 <header class="flex justify-between items-center mb-4">
-  <h1 class="crayons-title">Award Badges</h1>
-  <%= link_to "Back to Badge Achievements", admin_badge_achievements_path, class: "c-link c-link--block" %>
+  <h1 class="crayons-title">Award Chips</h1>
+  <%= link_to "Back to Chip Achievements", admin_badge_achievements_path, class: "c-link c-link--block" %>
 </header>
 <div class="crayons-card p-6">
   <%= form_with(url: admin_badge_achievements_award_badges_path, local: true, class: "flex flex-col gap-4") do |f| %>
     <div class="crayons-field">
-      <%= f.label :badge, "Badge", class: "crayons-field__label" %>
+      <%= f.label :badge, "Chip", class: "crayons-field__label" %>
       <%= f.select("badge", @all_badges.map { |badge| [badge.title, badge.slug] }, include_blank: true) %>
     </div>
     <div class="crayons-field">
@@ -19,7 +19,7 @@
     <div class="crayons-field">
       <%= f.label :message_markdown, "Override Default Message", class: "crayons-field__label" %>
       <p class="crayons-field__description">
-        Supports Markdown. This overrides the "message" sent in notifications and emails, it does not override the badge description.
+        Supports Markdown. This overrides the "message" sent in notifications and emails, it does not override the chip description.
       </p>
       <%= f.text_area :message_markdown, size: "40x3", class: "crayons-textfield" %>
     </div>
@@ -28,10 +28,10 @@
       <%= f.label :include_default_description, "Include Default Description", class: "crayons-field__label pt-2" %>
     </div>
     <p class="crayons-field__description">
-      If checked, the default badge <em>description</em> will be included above the message. If unchecked, only the message will be included.
+      If checked, the default chip <em>description</em> will be included above the message. If unchecked, only the message will be included.
     </p>
     <div>
-      <%= f.submit "Award Badges", class: "c-btn c-btn--primary" %>
+      <%= f.submit "Award Chips", class: "c-btn c-btn--primary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/badge_achievements/index.html.erb
+++ b/app/views/admin/badge_achievements/index.html.erb
@@ -5,12 +5,12 @@
   data-confirmation-modal-title-value="Confirm changes"
   data-confirmation-modal-size-value="m">
   <div class="crayons-notice crayons-notice--warning mb-4">
-    <strong>Note: If you remove a badge that is automatically rewarded it will simply be re-awarded despite being removed.</strong>
+    <strong>Note: If you remove a chip that is automatically rewarded it will simply be re-awarded despite being removed.</strong>
   </div>
 
   <div class="flex crayons-card crayons-card--secondary p-2">
     <div>
-      <%= link_to "Award Badge", admin_badge_achievements_award_badges_path, class: "c-link c-link--branded c-link--block" %>
+      <%= link_to "Award Chip", admin_badge_achievements_award_badges_path, class: "c-link c-link--branded c-link--block" %>
     </div>
     <div class="ml-auto">
       <%= search_form_for @q, url: admin_badge_achievements_path, class: "flex flex-row gap-1 items-center" do |f| %>
@@ -28,8 +28,8 @@
       <tr>
         <th scope="col">User ID</th>
         <th scope="col">User</th>
-        <th scope="col">Badge</th>
-        <th scope="col">Badge Image</th>
+        <th scope="col">Chip</th>
+        <th scope="col">Chip Image</th>
       </tr>
     </thead>
     <tbody class="crayons-card">
@@ -39,7 +39,7 @@
         <td><%= badge_achievement.user.username %></td>
         <td><%= badge_achievement.badge.title %></td>
         <td class="justify-center">
-          <img class="mx-auto mt-3" width="40" height="40" src="<%= badge_achievement.badge.badge_image %>" alt="badge image" loading="lazy" />
+          <img class="mx-auto mt-3" width="40" height="40" src="<%= badge_achievement.badge.badge_image %>" alt="chip image" loading="lazy" />
         </td>
         <td>
           <button

--- a/app/views/admin/badges/edit.html.erb
+++ b/app/views/admin/badges/edit.html.erb
@@ -1,7 +1,7 @@
 <header class="flex justify-between mb-4 items-center">
-  <h1 class="crayons-title"><%= "Edit badge #{@badge.id}" %></h1>
+  <h1 class="crayons-title"><%= "Edit chip #{@badge.id}" %></h1>
 
-  <%= link_to "Back to All Badges", admin_badges_path, class: "c-link c-link--block" %>
+  <%= link_to "Back to All Chips", admin_badges_path, class: "c-link c-link--block" %>
 </header>
 
 <%= form_for [:admin, @badge], method: :patch do |form| %>
@@ -9,7 +9,7 @@
     <div class="crayons-field">
       <%= form.label :title, "Title", class: "crayons-field__label" %>
       <p class="crayons-field__description">
-        Badge's link is auto-generated based on the title:
+        Chip's link is auto-generated based on the title:
         <%= link_to @badge.path, @badge.path %>
       </p>
       <%= form.text_field :title, class: "crayons-textfield" %>
@@ -21,9 +21,9 @@
     </div>
 
     <div class="crayons-field">
-      <%= form.label :badge_image, "Badge image", class: "crayons-field__label" %>
+      <%= form.label :badge_image, "Chip image", class: "crayons-field__label" %>
       <% if @badge.badge_image %>
-        <img class="mx-auto mt-3" width="60" height="60" src="<%= @badge.badge_image %>" alt="badge image">
+        <img class="mx-auto mt-3" width="60" height="60" src="<%= @badge.badge_image %>" alt="chip image">
       <% end %>
       <%= form.file_field :badge_image %>
     </div>
@@ -37,12 +37,12 @@
       <%= form.check_box :allow_multiple_awards, class: "crayons-checkbox" %>
       <%= form.label :allow_multiple_awards, class: "crayons-field__label" do %>
         Allow multiple awards
-      <p class="crayons-field__description">Allows this badge to be awarded multiple times to the same user</p>
+      <p class="crayons-field__description">Allows this chip to be awarded multiple times to the same user</p>
       <% end %>
     </div>
 
     <div>
-      <%= submit_tag "Update badge", class: "c-btn c-btn--primary" %>
+      <%= submit_tag "Update chip", class: "c-btn c-btn--primary" %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/badges/index.html.erb
+++ b/app/views/admin/badges/index.html.erb
@@ -1,7 +1,7 @@
 <header class="flex mb-6">
   <div class="flex gap-1 ml-auto">
-    <%= link_to "Create Badge", new_admin_badge_path, class: "c-link c-link--branded c-link--block" %>
-    <%= link_to "Award Badge", admin_badge_achievements_award_badges_path, class: "c-link c-link--branded c-link--block" %>
+    <%= link_to "Create Chip", new_admin_badge_path, class: "c-link c-link--branded c-link--block" %>
+    <%= link_to "Award Chip", admin_badge_achievements_award_badges_path, class: "c-link c-link--branded c-link--block" %>
   </div>
 </header>
 
@@ -10,7 +10,7 @@
     <tr>
       <th scope="col">Title</th>
       <th scope="col">Slug</th>
-      <th scope="col">Badge Image</th>
+      <th scope="col">Chip Image</th>
     </tr>
   </thead>
   <tbody class="crayons-card">
@@ -19,7 +19,7 @@
         <td><%= link_to badge.title, edit_admin_badge_path(badge.id) %></td>
         <td class="justify-center"><%= badge.slug %></td>
         <td class="justify-center">
-          <img class="mx-auto mt-3" width="40" height="40" src="<%= badge.badge_image %>" alt="badge image" loading="lazy" />
+          <img class="mx-auto mt-3" width="40" height="40" src="<%= badge.badge_image %>" alt="chip image" loading="lazy" />
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/badges/new.html.erb
+++ b/app/views/admin/badges/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="crayons-title mb-4">Create badge</h1>
+<h1 class="crayons-title mb-4">Create chip</h1>
 
 <%= form_for [:admin, @badge], method: :post do |form| %>
   <div class="crayons-card p-6 flex flex-col gap-4">
@@ -13,7 +13,7 @@
     </div>
 
     <div class="crayons-field">
-      <%= form.label :badge_image, "Badge image", class: "crayons-field__label" %>
+      <%= form.label :badge_image, "Chip image", class: "crayons-field__label" %>
       <%= form.file_field :badge_image, class: "" %>
     </div>
 
@@ -26,13 +26,13 @@
       <%= form.check_box :allow_multiple_awards, class: "crayons-checkbox" %>
       <%= form.label :allow_multiple_awards, class: "crayons-field__label" do %>
         Allow multiple awards
-      <p class="crayons-field__description">Allows this badge to be awarded multiple times to the same user</p>
+      <p class="crayons-field__description">Allows this chip to be awarded multiple times to the same user</p>
       <% end %>
     </div>
 
 
     <div>
-      <%= submit_tag "Create Badge", class: "c-btn c-btn--primary" %>
+      <%= submit_tag "Create Chip", class: "c-btn c-btn--primary" %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/mods/index.html.erb
+++ b/app/views/admin/mods/index.html.erb
@@ -32,7 +32,7 @@
         <th scope="col">ID</th>
         <th scope="col">Profile</th>
         <th scope="col">Comments</th>
-        <th scope="col">Badges</th>
+        <th scope="col">Chips</th>
         <th scope="col">Last Comment</th>
         <% if params[:state] == "potential" %>
           <th scope="col">Action</th>

--- a/app/views/badges/_badge_detail.html.erb
+++ b/app/views/badges/_badge_detail.html.erb
@@ -3,7 +3,7 @@
     <img
       class="badge-image"
       src="<%= optimized_image_url(badge.badge_image_url, width: 192) %>"
-      alt="<%= badge.title %> badge"
+      alt="<%= badge.title %> chip"
       title="<%= badge.title %>"
       loading="lazy" />
   </div>

--- a/app/views/badges/index.html.erb
+++ b/app/views/badges/index.html.erb
@@ -14,7 +14,7 @@
         <img
           class="badge-image"
           src="<%= optimized_image_url(badge.badge_image_url, width: 192) %>"
-          alt="<%= badge.title %> badge"
+          alt="<%= badge.title %> chip"
           title="<%= badge.title %>"
           loading="lazy" />
       </div>

--- a/app/views/mailers/notify_mailer/new_badge_email.html.erb
+++ b/app/views/mailers/notify_mailer/new_badge_email.html.erb
@@ -1,9 +1,9 @@
 <center>
   <p>
-    Congratulations, <%= @user.name %>! You received the <b><%= @badge.title %></b> badge!
+    Congratulations, <%= @user.name %>! You received the <b><%= @badge.title %></b> chip!
   </p>
   <p style="text-align:center;padding:20px 0px">
-    <img src="<%= @badge.badge_image_url %>" style="height:200px" alt="<%= @badge.title %> badge" loading="lazy" />
+    <img src="<%= @badge.badge_image_url %>" style="height:200px" alt="<%= @badge.title %> chip" loading="lazy" />
   </p>
 
   <% if @badge_achievement.include_default_description %>

--- a/app/views/mailers/notify_mailer/new_badge_email.text.erb
+++ b/app/views/mailers/notify_mailer/new_badge_email.text.erb
@@ -1,4 +1,4 @@
-Congratulations, <%= @user.name %>! You got the <%= @badge.title %> badge! Be sure to check out your profile.
+Congratulations, <%= @user.name %>! You got the <%= @badge.title %> chip! Be sure to check out your profile.
 
 <%= @badge.description if @badge_achievement.include_default_description %>
 

--- a/app/views/pages/_terms_text.en.html.erb
+++ b/app/views/pages/_terms_text.en.html.erb
@@ -95,7 +95,7 @@
     </h3>
 
     <p>
-      All uses of the <%= community_name %> logo, <%= community_name %> badges, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>.
+      All uses of the <%= community_name %> logo, <%= community_name %> chips, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>.
       <%= community_name %> reserves all rights, even if certain assets are included in <%= community_name %> open source projects. Please contact <%= contact_link %> with any questions or to request permission.
     </p>
 

--- a/app/views/pages/_terms_text.fr.html.erb
+++ b/app/views/pages/_terms_text.fr.html.erb
@@ -95,7 +95,7 @@
     </h3>
 
     <p>
-      All uses of the <%= community_name %> logo, <%= community_name %> badges, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>.
+      All uses of the <%= community_name %> logo, <%= community_name %> chips, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>.
       <%= community_name %> reserves all rights, even if certain assets are included in <%= community_name %> open source projects. Please contact <%= contact_link %> with any questions or to request permission.
     </p>
 

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -39,7 +39,7 @@
     </div>
     <div class="crayons-field crayons-field--checkbox">
       <%= f.check_box :email_badge_notifications, class: "crayons-checkbox" %>
-      <%= f.label :email_badge_notifications, "Send me an email when I receive a badge", class: "crayons-field__label" %>
+      <%= f.label :email_badge_notifications, "Send me an email when I receive a chip", class: "crayons-field__label" %>
     </div>
     <div class="crayons-field crayons-field--checkbox">
       <%= f.check_box :email_unread_notifications, class: "crayons-checkbox" %>

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -6,14 +6,14 @@ en:
       pinned: Article Pinned!
       unpinned: Article Unpinned!
     badge_achievements_controller:
-      deleted: Badge achievement has been deleted!
-      rewarded: Badges are being rewarded. The task will finish shortly.
+      deleted: Chip achievement has been deleted!
+      rewarded: Chips are being rewarded. The task will finish shortly.
       congrats: Congrats on your achievement! 🎉 And thank you for being such a vital part of %{community}!
-      award: Please choose a badge to award
+      award: Please choose a chip to award
       wrong: Something went wrong.
     badges_controller:
-      created: Badge has been created!
-      updated: Badge has been updated!
+      created: Chip has been created!
+      updated: Chip has been updated!
     broadcasts_controller:
       created: Broadcast has been created!
       deleted: Broadcast has been deleted!

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -6,14 +6,14 @@ fr:
       pinned: Article épinglé !
       unpinned: Article désépinglé !
     badge_achievements_controller:
-      deleted: La réalisation du badge a été supprimée !
-      rewarded: Les badges sont en train d'être récompensés. La tâche sera bientôt terminée.
+      deleted: La réalisation du chip a été supprimée !
+      rewarded: Les chips sont en train d'être récompensés. La tâche sera bientôt terminée.
       congrats: Félicitations pour votre succès! 🎉 Et merci d'être une partie si essentielle de %{community} !
-      award: Veuillez choisir un badge à décerner
+      award: Veuillez choisir un chip à décerner
       wrong: Quelque chose a mal fonctionné.
     badges_controller:
-      created: Le badge a été créé !
-      updated: Le badge a été mis à jour !
+      created: Le chip a été créé !
+      updated: Le chip a été mis à jour !
     broadcasts_controller:
       created: Le Broadcast a été créée !
       deleted: Le Broadcast a été supprimée !

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -32,7 +32,7 @@ en:
     locked: Discussion was successfully locked!
     unlocked: Discussion was successfully unlocked!
   email_subscriptions_controller:
-    badge_notifications: badge notifications
+    badge_notifications: chip notifications
     comment_notifications: comment notifications
     digest_emails: "%{community} digest emails"
     follower_notifications: follower notifications

--- a/config/locales/controllers/fr.yml
+++ b/config/locales/controllers/fr.yml
@@ -32,7 +32,7 @@ fr:
     locked: La discussion a été verrouillée avec succès !
     unlocked: La discussion a été déverrouillée avec succès !
   email_subscriptions_controller:
-    badge_notifications: notifications de badges
+    badge_notifications: notifications de chips
     comment_notifications: notifications de commentaires
     digest_emails: "%{community} e-mails récapitulatifs"
     follower_notifications: notifications de followers

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -57,7 +57,7 @@ en:
         email_comment_notifications: Send me an email when someone replies to me in a comment thread
         email_follower_notifications: Send me an email when someone new follows me
         email_mention_notifications: Send me an email when someone mentions me
-        email_badge_notifications: Send me an email when I receive a badge
+        email_badge_notifications: Send me an email when I receive a chip
         email_unread_notifications: Send me occasional reminders that I have unread notifications on %{community}
         mobile_mention_notifications: Send me a push notification when someone mentions me
         mobile_comment_notifications: Send me a push notification when someone replies to me in a comment thread

--- a/config/locales/helpers/fr.yml
+++ b/config/locales/helpers/fr.yml
@@ -57,7 +57,7 @@ fr:
         email_comment_notifications: Envoyez-moi un e-mail lorsque quelqu'un me répond dans un fil de commentaires
         email_follower_notifications: Envoyez-moi un e-mail lorsque quelqu'un me suit
         email_mention_notifications: Envoyez-moi un e-mail lorsque quelqu'un me mentionne
-        email_badge_notifications: Envoyez-moi un e-mail lorsque je reçois un badge
+        email_badge_notifications: Envoyez-moi un e-mail lorsque je reçois un chip
         email_unread_notifications: Envoyez-moi des rappels occasionnels lorsque j'ai des notifications non lues sur %{community}
         mobile_mention_notifications: Envoyez-moi une notification push lorsque quelqu'un me mentionne
         mobile_comment_notifications: Envoyez-moi une notification push lorsque quelqu'un me répond dans un fil de commentaires

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -29,7 +29,7 @@ en:
       unread_notifications:
         one: "🔥 You have %{count} unread notifications on %{community}"
         other: "🔥 You have %{count} unread notifications on %{community}"
-      new_badge: You just got a badge
+      new_badge: You just got a chip
       video_upload: Your video upload is complete
     verification_mailer:
       from: "%{community} Email Verification <%{email}>"

--- a/config/locales/mailers/fr.yml
+++ b/config/locales/mailers/fr.yml
@@ -29,7 +29,7 @@ fr:
       unread_notifications:
         one: "🔥 Vous avez %{count} notification non lue sur %{community}"
         other: "🔥 Vous avez %{count} notifications non lues sur  %{community}"
-      new_badge: Vous venez de recevoir un badge
+      new_badge: Vous venez de recevoir un chip
       video_upload: Le téléchargement de votre vidéo est terminé
     verification_mailer:
       from: "%{community} Vérification de l'e-mail <%{email}>"

--- a/config/locales/services/en.yml
+++ b/config/locales/services/en.yml
@@ -19,8 +19,8 @@ en:
       award_streak:
         longest: 16 weeks! You've achieved the longest writing streak possible. Keep up the amazing contributions to our community!
         message:
-          one: "Congrats on achieving this streak! Consistent writing is hard. The next streak badge you can get is the %{count} Week Badge. 😉"
-          other: "Congrats on achieving this streak! Consistent writing is hard. The next streak badge you can get is the %{count} Week Badge. 😉"
+          one: "Congrats on achieving this streak! Consistent writing is hard. The next streak chip you can get is the %{count} Week Chip. 😉"
+          other: "Congrats on achieving this streak! Consistent writing is hard. The next streak chip you can get is the %{count} Week Chip. 😉"
       award_yearly_club:
         message:
           one: Happy %{community} birthday! Can you believe it's been %{count} year already?!
@@ -29,8 +29,8 @@ en:
       thank_you: Thank you so much for your contributions!
       community_wellness:
         first: Thank you for participating in constructive conversation! You posted two or more comments this week. Keep it up to continue the streak!
-        longest: 32 weeks! You've achieved the longest streak possible for the Community Wellness badge. Amazing job engaging in the community. Keep up your amazing contributions to our community!
-        other: Congrats on achieving a %{weeks} week streak for the Community Wellness Badge! Keep the constructive comments flowing to continue the streak!
+        longest: 32 weeks! You've achieved the longest streak possible for the Community Wellness chip. Amazing job engaging in the community. Keep up your amazing contributions to our community!
+        other: Congrats on achieving a %{weeks} week streak for the Community Wellness Chip! Keep the constructive comments flowing to continue the streak!
       thumbs_up: Thank you for your efforts reviewing posts and reaching %{count} thumbs-up reactions!
     broadcasts:
       welcome_notification:

--- a/config/locales/services/fr.yml
+++ b/config/locales/services/fr.yml
@@ -19,8 +19,8 @@ fr:
       award_streak:
         longest: 16 semaines ! Vous avez réalisé la plus longue séquence d’écriture possible. Continuez vos incroyables contributions à notre communauté!
         message:
-          one: "Félicitations pour avoir réalisé cette séquence ! Une écriture cohérente est difficile. Le prochain badge de séquence que vous pouvez obtenir est le badge de semaine %{count}. 😉"
-          other: "Félicitations pour avoir réalisé cette séquence ! Une écriture cohérente est difficile. Le prochain badge de séquence que vous pouvez obtenir est le badge de semaine %{count}. 😉"
+          one: "Félicitations pour avoir réalisé cette séquence ! Une écriture cohérente est difficile. Le prochain chip de séquence que vous pouvez obtenir est le chip de semaine %{count}. 😉"
+          other: "Félicitations pour avoir réalisé cette séquence ! Une écriture cohérente est difficile. Le prochain chip de séquence que vous pouvez obtenir est le chip de semaine %{count}. 😉"
       award_yearly_club:
         message:
           one: Joyeux anniversaire %{community} ! Pouvez-vous croire que cela fait déjà %{count} année ?!
@@ -29,8 +29,8 @@ fr:
       thank_you: Merci beaucoup pour vos contributions !
       community_wellness:
         first: Merci de participer à une conversation constructive ! Vous avez posté deux commentaires ou plus cette semaine. Continuez comme ça pour poursuivre la série !
-        longest: 32 semaines ! Vous avez réalisé la plus longue séquence possible pour le badge Community Wellness. Un travail incroyable en m'engageant dans la communauté. Continuez vos incroyables contributions à notre communauté !
-        other: Félicitations, vous avez réalisé %{weeks} semaines consécutives pour le badge de bien-être communautaire ! Continuez à recevoir des commentaires constructifs pour continuer la séquence !
+        longest: 32 semaines ! Vous avez réalisé la plus longue séquence possible pour le chip Community Wellness. Un travail incroyable en m'engageant dans la communauté. Continuez vos incroyables contributions à notre communauté !
+        other: Félicitations, vous avez réalisé %{weeks} semaines consécutives pour le chip de bien-être communautaire ! Continuez à recevoir des commentaires constructifs pour continuer la séquence !
       thumbs_up: Merci pour vos efforts en examinant les messages et en obtenant %{count} réactions positives !
     broadcasts:
       welcome_notification:

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -266,7 +266,7 @@ en:
           reactions: Reactions
           followers: Followers
           following: Following
-          badges: Badges
+          badges: Chips
           learn: Learn more
           credits:
             subtitle: Credits
@@ -311,8 +311,8 @@ en:
               restricted_liquid_tag: Restricted Liquid Tag
               single_resource_admin: Single Resource Admin
               resource_admin_article: Article Admin
-              resource_admin_badge: Badge Admin
-              resource_admin_badge_achievement: Badge Achievement Admin
+              resource_admin_badge: Chip Admin
+              resource_admin_badge_achievement: Chip Achievement Admin
               resource_admin_broadcast: Broadcast Admin
               resource_admin_comment: Comment Admin
               resource_admin_config: Config Admin
@@ -424,8 +424,8 @@ en:
           Super Admin: Super Admin
           Resource Admin: Resource Admin
           "Resource Admin: Article": "Resource Admin: Article"
-          "Resource Admin: Badge": "Resource Admin: Badge"
-          "Resource Admin: BadgeAchievement": "Resource Admin: BadgeAchievement"
+          "Resource Admin: Badge": "Resource Admin: Chip"
+          "Resource Admin: BadgeAchievement": "Resource Admin: ChipAchievement"
           "Resource Admin: Broadcast": "Resource Admin: Broadcast"
           "Resource Admin: Comment": "Resource Admin: Comment"
           "Resource Admin: Config": "Resource Admin: Config"

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -258,7 +258,7 @@ fr:
           reactions: Reactions
           followers: Followers
           following: Following
-          badges: Badges
+          badges: Chips
           learn: Learn more
           credits:
             subtitle: Credits
@@ -303,8 +303,8 @@ fr:
               restricted_liquid_tag: Restricted Liquid Tag
               single_resource_admin: Single Resource Admin
               resource_admin_article: Article Admin
-              resource_admin_badge: Badge Admin
-              resource_admin_badge_achievement: Badge Achievement Admin
+              resource_admin_badge: Chip Admin
+              resource_admin_badge_achievement: Chip Achievement Admin
               resource_admin_broadcast: Broadcast Admin
               resource_admin_comment: Comment Admin
               resource_admin_config: Config Admin
@@ -411,8 +411,8 @@ fr:
           Super Admin: Super Admin
           Resource Admin: Resource Admin
           "Resource Admin: Article": "Resource Admin: Article"
-          "Resource Admin: Badge": "Resource Admin: Badge"
-          "Resource Admin: BadgeAchievement": "Resource Admin: BadgeAchievement"
+          "Resource Admin: Badge": "Resource Admin: Chip"
+          "Resource Admin: BadgeAchievement": "Resource Admin: ChipAchievement"
           "Resource Admin: Broadcast": "Resource Admin: Broadcast"
           "Resource Admin: Comment": "Resource Admin: Comment"
           "Resource Admin: Config": "Resource Admin: Config"

--- a/config/locales/views/credits/en.yml
+++ b/config/locales/views/credits/en.yml
@@ -46,7 +46,7 @@ en:
             user: You have %{count} credits.
         how:
           subtitle: How can I earn credits?
-          desc_html: Members receive <strong>5 credits</strong> for every profile badge you earn.
+          desc_html: Members receive <strong>5 credits</strong> for every profile chip you earn.
       purchase: Purchase additional credits
       tag: 'Tag: %{name}'
       status:

--- a/config/locales/views/credits/fr.yml
+++ b/config/locales/views/credits/fr.yml
@@ -46,7 +46,7 @@ fr:
             user: You have %{count} credits.
         how:
           subtitle: How can I earn credits?
-          desc_html: Members receive <strong>5 credits</strong> for every profile badge you earn.
+          desc_html: Members receive <strong>5 credits</strong> for every profile chip you earn.
       purchase: Purchase additional credits
       tag: 'Tag: %{name}'
       status:

--- a/config/locales/views/misc/en.yml
+++ b/config/locales/views/misc/en.yml
@@ -3,15 +3,15 @@ en:
   views:
     badges:
       meta:
-        title: Badges
+        title: Chips
       all:
-        one: Show one badge
-        other: Show all %{count} badges
-      heading: Badges
-      desc: Receive badges for being awesome! Click on a badge to see how you can earn it.
+        one: Show one chip
+        other: Show all %{count} chips
+      heading: Chips
+      desc: Receive chips for being awesome! Click on a chip to see how you can earn it.
       icon_close: Close
       gotit: Got it
-      indicator: "%{user} earned this badge %{number} times."
+      indicator: "%{user} earned this chip %{number} times."
     campaign:
       subtitle: Stories (%{count})
       view: See all posts

--- a/config/locales/views/misc/fr.yml
+++ b/config/locales/views/misc/fr.yml
@@ -3,15 +3,15 @@ fr:
   views:
     badges:
       meta:
-        title: Badges
+        title: Chips
       all:
-        one: Show one badge
-        other: Show all %{count} badges
-      heading: Badges
-      desc: Receive badges for being awesome! Click on a badge to see how you can earn it.
+        one: Show one chip
+        other: Show all %{count} chips
+      heading: Chips
+      desc: Receive chips for being awesome! Click on a chip to see how you can earn it.
       icon_close: Close
       gotit: Got it
-      indicator: "%{user} a obtenu ce badge %{number} fois."
+      indicator: "%{user} a obtenu ce chip %{number} fois."
     campaign:
       subtitle: Stories (%{count})
       view: See all posts

--- a/config/locales/views/notifications/en.yml
+++ b/config/locales/views/notifications/en.yml
@@ -14,7 +14,7 @@ en:
         mod_opt_out: Don't want to receive these notifications?
         change_settings: Change settings
       badge:
-        heading_html: You received the %{badge} badge
+        heading_html: You received the %{badge} chip
         awarded_html: "You also get %{credits} to use for %{listings} if you have anything you'd like to promote. 🎉"
         credits:
           one: "%{count} new credits"

--- a/config/locales/views/notifications/fr.yml
+++ b/config/locales/views/notifications/fr.yml
@@ -14,7 +14,7 @@ fr:
         mod_opt_out: Don't want to receive these notifications?
         change_settings: Change settings
       badge:
-        heading_html: You received the %{badge} badge
+        heading_html: You received the %{badge} chip
         awarded_html: "You also get %{credits} to use for %{listings} if you have anything you'd like to promote. 🎉"
         credits:
           one: "%{count} new credits"

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe NotifyMailer do
     include_examples "#renders_proper_email_headers"
 
     it "renders proper subject" do
-      expect(email.subject).to eq("You just got a badge")
+      expect(email.subject).to eq("You just got a chip")
     end
 
     it "renders proper receiver" do

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -43,16 +43,16 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         post admin_badge_achievements_award_badges_path, params: {
           badge: badge.slug,
           usernames: usernames_string,
-          message_markdown: "you got a badge nice one"
+          message_markdown: "you got a chip nice one"
         }
         expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-          usernames_array, badge.slug, "you got a badge nice one", false
+          usernames_array, badge.slug, "you got a chip nice one", false
         )
-        expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
+        expect(request.flash[:success]).to include("Chips are being rewarded. The task will finish shortly.")
       end
     end
 
-    it "awards badges" do
+    it "awards chips" do
       allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
       post admin_badge_achievements_award_badges_path, params: {
         badge: badge.slug,
@@ -65,10 +65,10 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         "Hinder me? Thou fool. No living man may hinder me!",
         false,
       )
-      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
+      expect(request.flash[:success]).to include("Chips are being rewarded. The task will finish shortly.")
     end
 
-    it "awards badges with default a message" do
+    it "awards chips with default a message" do
       allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
       post admin_badge_achievements_award_badges_path, params: {
         badge: badge.slug,
@@ -80,7 +80,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
                                                badge.slug,
                                                expected_message,
                                                false)
-      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
+      expect(request.flash[:success]).to include("Chips are being rewarded. The task will finish shortly.")
     end
 
     it "includes default description if passed as true" do
@@ -96,7 +96,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
                                                badge.slug,
                                                expected_message,
                                                true)
-      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
+      expect(request.flash[:success]).to include("Chips are being rewarded. The task will finish shortly.")
     end
 
     it "does not include default description if passed as false" do
@@ -112,7 +112,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
                                                badge.slug,
                                                expected_message,
                                                false)
-      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
+      expect(request.flash[:success]).to include("Chips are being rewarded. The task will finish shortly.")
     end
 
     it "does not award a badge and raises an error if a badge is not specified" do

--- a/spec/requests/badges_spec.rb
+++ b/spec/requests/badges_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Badges" do
 
       it "shows all the badges" do
         get "/badges"
-        expect(response.body).to include "Badges"
+        expect(response.body).to include "Chips"
         badges.each do |badge|
           expect(response.body).to include CGI.escapeHTML(badge.badge_image_url)
         end
@@ -21,7 +21,7 @@ RSpec.describe "Badges" do
     context "when logged out" do
       it "shows all the badges" do
         get "/badges"
-        expect(response.body).to include "Badges"
+        expect(response.body).to include "Chips"
         badges.each do |badge|
           expect(response.body).to include CGI.escapeHTML(badge.badge_image_url)
         end

--- a/spec/system/admin/admin_awards_badges_spec.rb
+++ b/spec/system/admin/admin_awards_badges_spec.rb
@@ -1,22 +1,22 @@
 require "rails_helper"
 
-RSpec.describe "Admin awards badges" do
+RSpec.describe "Admin awards chips" do
   let(:admin) { create(:user, :super_admin) }
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
   let(:badges) { Badge.pluck(:title) }
 
-  def award_two_badges
+  def award_two_chips
     find(:xpath, "//option[contains(text(), \"#{badges.last}\")]").select_option
     fill_in "usernames", with: "#{user.username}, #{user2.username}"
     fill_in "message_markdown", with: "He who controls the spice controls the universe."
-    click_on "Award Badges"
+    click_on "Award Chips"
   end
 
-  def award_no_badges
+  def award_no_chips
     fill_in "usernames", with: "#{user.username}, #{user2.username}"
     fill_in "message_markdown", with: "He who controls the spice controls the universe."
-    click_on "Award Badges"
+    click_on "Award Chips"
   end
 
   before do
@@ -26,31 +26,31 @@ RSpec.describe "Admin awards badges" do
   end
 
   it "loads the view" do
-    expect(page).to have_content("Badges")
+    expect(page).to have_content("Chips")
   end
 
-  it "lists the badges" do
+  it "lists the chips" do
     badges.each do |badge|
       expect(page).to have_content(badge)
     end
   end
 
-  it "awards badges" do
+  it "awards chips" do
     expect do
-      sidekiq_perform_enqueued_jobs { award_two_badges }
+      sidekiq_perform_enqueued_jobs { award_two_chips }
     end.to change { user.badges.count }.by(1).and change { user2.badges.count }.by(1)
-    expect(page).to have_content("Badges are being rewarded. The task will finish shortly")
+    expect(page).to have_content("Chips are being rewarded. The task will finish shortly")
 
     visit "/#{user.username}/"
 
     expect(page).to have_css("img[src='#{Badge.last.badge_image.url}']")
   end
 
-  it "does not award badges if no badge is selected", js: true do
+  it "does not award chips if no chip is selected", js: true do
     expect do
-      sidekiq_perform_enqueued_jobs { award_no_badges }
+      sidekiq_perform_enqueued_jobs { award_no_chips }
     end.not_to change { user.badges.count }
 
-    expect(page).to have_content("Please choose a badge to award")
+    expect(page).to have_content("Please choose a chip to award")
   end
 end

--- a/spec/system/admin/admin_visits_badge_achievements_spec.rb
+++ b/spec/system/admin/admin_visits_badge_achievements_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe "Admin visits badge achievements page" do
     visit admin_badge_achievements_path
   end
 
-  it "nests the content under Badges" do
-    expect(find("h1.crayons-title").text).to eq("Badges")
+  it "nests the content under Chips" do
+    expect(find("h1.crayons-title").text).to eq("Chips")
   end
 
-  it "highlights the Badges menu item in the sidebar" do
+  it "highlights the Chips menu item in the sidebar" do
     within('nav[aria-label="Admin"]') do
-      expect(find("[aria-current='page']").text).to eq("Badges")
+      expect(find("[aria-current='page']").text).to eq("Chips")
     end
   end
 end


### PR DESCRIPTION
## Summary
- rename user-facing "badge" text to "chip" in views, emails and translations
- update admin pages and specs to match new chip terminology

## Testing
- `bin/rspec spec/mailers/notify_mailer_spec.rb` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_6890ff39e9d48323950b71f652f705d2