### PR TITLE
Use stable social image filenames per article

### DIFF
--- a/app/uploaders/article_image_uploader.rb
+++ b/app/uploaders/article_image_uploader.rb
@@ -1,10 +1,14 @@
 require "open-uri"
 class ArticleImageUploader < BaseUploader
+  attr_writer :override_filename
+
   def store_dir
     "uploads/articles/"
   end
 
   def filename
+    return @override_filename if @override_filename
+
     "#{Array.new(20) { rand(36).to_s(36) }.join}.#{file.extension}" if original_filename.present?
   end
 

--- a/spec/services/images/generate_social_image_magickally_spec.rb
+++ b/spec/services/images/generate_social_image_magickally_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Images::GenerateSocialImageMagickally, type: :model do
         described_class.call(user)
         expect(generator).to have_received(:generate_magickally).once
           .with(
+            article: article,
             title: article.title,
             date: article.readable_publish_date,
             author_name: user.name,
@@ -267,6 +268,7 @@ RSpec.describe Images::GenerateSocialImageMagickally, type: :model do
           allow(result_image).to receive(:write)
 
           allow(ArticleImageUploader).to receive(:new).and_return(uploader)
+          allow(uploader).to receive(:override_filename=)
           allow(uploader).to receive(:store!)
           allow(uploader).to receive(:url).and_return("http://example.com/social_image.png")
 
@@ -274,11 +276,12 @@ RSpec.describe Images::GenerateSocialImageMagickally, type: :model do
         end
 
         it "creates a tempfile, writes the image, uploads the image, then cleans up the tempfile" do
-          expect(generator.send(:upload_result, result_image)).to eq "http://example.com/social_image.png"
+          expect(generator.send(:upload_result, result_image, article)).to eq "http://example.com/social_image.png"
 
           expect(Tempfile).to have_received(:new).with(["output", ".png"])
           expect(result_image).to have_received(:write).with(tempfile.path)
           expect(ArticleImageUploader).to have_received(:new)
+          expect(uploader).to have_received(:override_filename=).with("social-#{article.id}.png")
           expect(uploader).to have_received(:store!).with(tempfile)
           expect(tempfile).to have_received(:close)
           expect(tempfile).to have_received(:unlink)


### PR DESCRIPTION
## Summary
- Save generated social images to a deterministic `social-<article_id>.png`
- Pass article context to generation so existing image gets replaced on regeneration
- Update tests for idempotent social image storage

## Testing
- `bundle exec rubocop app/services/images/generate_social_image_magickally.rb app/uploaders/article_image_uploader.rb spec/services/images/generate_social_image_magickally_spec.rb` *(fails: command not found: rubocop)*
- `bundle install` *(fails: Gemfile requires Ruby 3.3.0 but system is 3.4.4)*
- `bundle exec rspec spec/services/images/generate_social_image_magickally_spec.rb spec/uploaders/article_image_uploader_spec.rb` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_689b9c7690588323bf95af13682d6478